### PR TITLE
chore: update Gradle wrapper

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
## Summary
- update Gradle wrapper to 4.10.3 for compatibility with newer Android Studio

## Testing
- `mise install java@8` (failed: TunnelUnsuccessful)
- `./gradlew help` (failed: Unable to tunnel through proxy HTTP/1.1 403)


------
https://chatgpt.com/codex/tasks/task_e_6891163f77a4832a9eae5f7138ec1731