### PR TITLE
Define signing config properties

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,10 +9,10 @@ android {
     signingConfigs {
 
         devaldroid {
-            keyAlias config_keyAlias
-            keyPassword config_keyPassword
-            storeFile file(config_storeFile)
-            storePassword config_storePassword
+            keyAlias project.property("config_keyAlias")
+            keyPassword project.property("config_keyPassword")
+            storeFile file(project.property("config_storeFile"))
+            storePassword project.property("config_storePassword")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,9 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Signing configuration properties
+config_keyAlias=keyAlias
+config_keyPassword=keyPassword
+config_storeFile=keystore.jks
+config_storePassword=storePassword


### PR DESCRIPTION
## Summary
- Load signing configuration from project properties in `app/build.gradle`
- Add placeholder signing values to `gradle.properties`

## Testing
- `bash ./gradlew -q tasks` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68911b01463c832ab212a01bafa11017